### PR TITLE
gitignore .env and .DS_Store file

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -75,8 +75,11 @@ web_modules/
 .yarn-integrity
 
 # dotenv environment variables file
-#.env
+.env
 .env.test
+
+### OSX ###
+*.DS_Store
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -72,6 +72,9 @@ web_modules/
 .env
 .env.test
 
+### OSX ###
+*.DS_Store
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache


### PR DESCRIPTION
Updated .gitignore file to remove .env and .DS_Store from version control.